### PR TITLE
Add support for Aarch64 and RedoxOS

### DIFF
--- a/deps/helper/Cargo.toml
+++ b/deps/helper/Cargo.toml
@@ -7,4 +7,4 @@ description = "Test helper for the `va_list` crate. Not for user consumption."
 license = "MIT"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/deps/helper/build.rs
+++ b/deps/helper/build.rs
@@ -1,5 +1,7 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-	::gcc::compile_library("libva_list_test.a", &["src/helper.c"]);
+    ::cc::Build::new()
+        .file("src/helper.c")
+        .compile("libva_list_test.a");
 }

--- a/src/impl-aarch64-elf.rs
+++ b/src/impl-aarch64-elf.rs
@@ -1,0 +1,76 @@
+use std::{mem, ptr};
+use super::VaPrimitive;
+
+pub struct VaList(*mut VaListInner);
+
+#[repr(C)]
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct VaListInner {
+    stack: *const (),
+    gr_top: *const (),
+    vr_top: *const (),
+    gr_offs: i32,
+    vr_offs: i32,
+}
+
+impl VaList {
+    fn inner(&mut self) -> &mut VaListInner {
+        // This pointer should be valid
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl VaListInner {
+    pub unsafe fn get_gr<T>(&mut self) -> T {
+        assert!(!self.gr_top.is_null());
+        let rv = ptr::read((self.gr_top as usize - self.gr_offs.abs() as usize) as *const _);
+        self.gr_offs += 8;
+        rv
+    }
+
+    pub unsafe fn get_vr<T>(&mut self) -> T {
+        assert!(!self.vr_top.is_null());
+        let rv = ptr::read((self.vr_top as usize - self.vr_offs.abs() as usize) as *const _);
+        self.vr_offs += 16;
+        rv
+    }
+}
+
+impl<T: 'static> VaPrimitive for *const T {
+    unsafe fn get(list: &mut VaList) -> Self {
+        <usize>::get(list) as *const T
+    }
+}
+
+macro_rules! impl_va_prim_gr {
+    ($u: ty, $s: ty) => {
+        impl VaPrimitive for $u {
+            unsafe fn get(list: &mut VaList) -> Self {
+                list.inner().get_gr()
+            }
+        }
+        impl VaPrimitive for $s {
+            unsafe fn get(list: &mut VaList) -> Self {
+                mem::transmute(<$u>::get(list))
+            }
+        }
+    };
+}
+
+macro_rules! impl_va_prim_vr {
+    ($($t:ty),+) => {
+        $(
+            impl VaPrimitive for $t {
+                unsafe fn get(list: &mut VaList) -> Self {
+                    list.inner().get_vr()
+                }
+            }
+        )+
+    };
+}
+
+impl_va_prim_gr!{ usize, isize }
+impl_va_prim_gr!{ u64, i64 }
+impl_va_prim_gr!{ u32, i32 }
+impl_va_prim_vr!{ f64, f32 }

--- a/src/impl-x86_64-elf.rs
+++ b/src/impl-x86_64-elf.rs
@@ -29,6 +29,7 @@ impl VaListInner {
     fn check_space(&self, num_gp: u32, num_fp: u32) -> bool {
         !(self.gp_offset > 48 - num_gp * 8 || self.fp_offset > 304 - num_fp * 16)
     }
+
     unsafe fn get_gp<T>(&mut self) -> T {
         let n_gp = (mem::size_of::<T>() + 7) / 8;
         assert!(self.check_space(n_gp as u32, 0));
@@ -36,6 +37,7 @@ impl VaListInner {
         self.gp_offset += (8 * n_gp) as u32;
         rv
     }
+
     unsafe fn get_overflow<T>(&mut self) -> T {
         let align = mem::align_of::<T>();
         // 7. Align overflow_reg_area upwards to a 16-byte boundary if alignment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ mod std {
 }
 
 // x86_64 on unix platforms is _usually_ ELF.
-#[cfg(all(target_arch = "x86_64", any(target_family = "unix", target_os = "tifflin")))]
+#[cfg(all(target_arch = "x86_64",
+          any(target_family = "unix", target_os = "redox", target_os = "tifflin")))]
 #[path = "impl-x86_64-elf.rs"]
 mod imp;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,11 @@ mod imp;
 #[path = "impl-x86-sysv.rs"]
 mod imp;
 
+// aarch64
+#[cfg(all(target_arch = "aarch64", any(target_family = "unix", target_os = "redox")))]
+#[path = "impl-aarch64-elf.rs"]
+mod imp;
+
 // arm+unix = cdecl
 #[cfg(all(target_arch = "arm", target_family = "unix"))]
 #[path = "impl-arm-sysv.rs"]


### PR DESCRIPTION
 - Add support for Aarch64
 - Add support for RedoxOS
 - Use the `cc` crate instead of `gcc`

Tests pass on my rpi3. It would probably be good to do
a bit more checking for correctess. I might try to add
some more test cases.