### PR TITLE
Add support for macos aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "va_list"
-version = "0.1.3"
-authors = [ "John Hodge <tpg@mutabah.net>" ]
+version = "0.1.4"
+authors = [
+    "John Hodge <tpg@mutabah.net>",
+    "Georgy Moshkin <gmoshkin@picodata.io>",
+]
 description = "Provides a rust implementation of the 'va_list' type for a small set of ABIs. Allowing rust implementations of functions like vprintf."
 repository = "https://github.com/thepowersgang/va_list-rs"
 readme = "README.md"

--- a/src/impl-aarch64-macos.rs
+++ b/src/impl-aarch64-macos.rs
@@ -1,0 +1,39 @@
+use std::ffi::c_void;
+use super::VaPrimitive;
+
+#[repr(transparent)]
+pub struct VaList(VaListInner);
+
+#[repr(transparent)]
+pub struct VaListInner {
+    ptr: *mut c_void,
+}
+
+impl VaListInner {
+    unsafe fn get<T>(&mut self) -> T {
+        let res = std::ptr::read(self.ptr as _);
+        self.ptr = self.ptr.add(8);
+        res
+    }
+}
+
+impl<T: 'static> VaPrimitive for *const T {
+    unsafe fn get(list: &mut VaList) -> Self {
+        list.0.get()
+    }
+}
+
+macro_rules! impl_va_prim {
+    ($($t:ty),+) => {
+        $(
+            impl VaPrimitive for $t {
+                unsafe fn get(list: &mut VaList) -> Self {
+                    list.0.get()
+                }
+            }
+        )+
+    };
+}
+
+impl_va_prim!{ usize, isize, u64, i64, u32, i32, f64, f32 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,22 @@ mod imp;
 mod imp;
 
 // aarch64
-#[cfg(all(target_arch = "aarch64", any(target_family = "unix", target_os = "redox")))]
+#[cfg(all(
+    target_arch = "aarch64",
+    any(target_family = "unix", target_os = "redox"),
+    not(any(target_os = "macos", target_os = "ios")),
+))]
 #[path = "impl-aarch64-elf.rs"]
 mod imp;
 
 // arm+unix = cdecl
 #[cfg(all(target_arch = "arm", target_family = "unix"))]
 #[path = "impl-arm-sysv.rs"]
+mod imp;
+
+// aarch64+macos
+#[cfg(all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")))]
+#[path = "impl-aarch64-macos.rs"]
 mod imp;
 
 /// Rust version of C's `va_list` type from the `stdarg.h` header

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -32,8 +32,10 @@ fn trivial_values() {
     // Trivial test: Pass four random-ish sized integers
     test_va_list!(
         4,
-        (123456u32, 2u64, 1i32, -23i64),
+        (0xaabbaabbu32, 0xccddccddu32, 123456u32, 2u64, 1i32, -23i64),
         |_count, mut list: va_list::VaList| unsafe {
+            assert_eq!(list.get::<u32>(), 0xaabbaabb);
+            assert_eq!(list.get::<u32>(), 0xccddccdd);
             assert_eq!(list.get::<u32>(), 123456u32);
             assert_eq!(list.get::<u64>(), 2u64);
             assert_eq!(list.get::<i32>(), 1i32);


### PR DESCRIPTION
Seems to work for 32/64 bit values.

We need this on our [tarantool-module](https://github.com/picodata/tarantool-module) project, so we would appreciate if you merge this.