### PR TITLE
Supporting Windows/arm64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,8 @@ def_platforms! {
 		) {
 		mod x8664_elf = "impl-x86_64-elf.rs";
 	}
-	// x86_64 windows = ?cdecl (64-bit)
-	if all(target_arch = "x86_64", target_family = "windows") {
+	// x86_64/arm64 windows = cdecl (64-bit)
+	if all(any(target_arch = "x86_64", target_arch = "aarch64"), target_family = "windows") {
 		mod x8664_win64 = "impl-cdecl64.rs";
 	}
 


### PR DESCRIPTION
The ABI is similar to x64:
https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention#varargs
https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions#addendum-variadic-functions