### PR TITLE
Support RISC-V 64 and LoongArch64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,16 @@ def_platforms! {
 		mod aarch64_elf = "impl-aarch64-elf.rs";
 	}
 
+	// riscv64+unix = cdecl (64-bit)
+	if all(target_arch = "riscv64", target_family = "unix") {
+		mod riscv64_unix = "impl-cdecl64.rs";
+	}
+
+	// loongarch64+unix = cdecl (64-bit)
+	if all(target_arch = "loongarch64", target_family = "unix") {
+		mod loongarch64_unix = "impl-cdecl64.rs";
+	}
+
 	// aarch64+macos = cdecl (64-bit)
 	if all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")) {
 		mod aarch64_macos = "impl-cdecl64.rs";


### PR DESCRIPTION
This library seemed like it could be easily ported to Linux RISC-V 64/LoongArch64 platforms, so I did it. I tested it on the following platforms and it passed:

RISC-V 64:
```
       _,met$$$$$gg.          glavo@starfive
    ,g$$$$$$$$$$$$$$$P.       --------------
  ,g$$P"     """Y$$.".        OS: Debian GNU/Linux bookworm/sid riscv64
 ,$$P'              `$$$.     Host: StarFive VisionFive V2
',$$P       ,ggs.     `$$b:   Kernel: 6.1.31-starfive
`d$$'     ,$P"'   .    $$$    Uptime: 30 mins
 $$P      d$'     ,    $$P    Packages: 1350 (dpkg)
 $$:      $$.   -    ,d$$'    Shell: fish 3.5.1
 $$;      Y$b._   _,d$P'      Terminal: /dev/pts/0
 Y$$.    `.`"Y$$$$P"'         CPU: (4) @ 1.500GHz
 `$$b      "-.__              Memory: 331MiB / 3874MiB
   `Y$$.
     `$$b.
       `Y$$b.
          `"Y$b._
              `"""
```

LoongArch64:
```
                  __                          glavo@3a6000
               gpBBBBBBBBBP                   ------------
           _gBBBBBBBBBRP                      OS: AOSC OS (loongarch64)
         4BBBBBBBBRP  ,_____                  Host: Loongson-3A6000-7A2000-1w-V0.1-EVB
              `"" _g@@@@@@@@@@@@@%g>          Kernel: 6.10.7-aosc-main
              __@@@@@@@@@@@@@@@@P"  ___       Uptime: 13 mins
           _g@@@@@@@@@@@@@@@N"` _gN@@@@@N^    Packages: 1447 (dpkg)
       _w@@@@@@@@@@@@@@@@P" _g@@@@@@@P"       Shell: fish 3.7.1
    _g@@@@@@@@@@@@@@@N"`  VMNN@NNNM^`         Resolution: 1920x1080
  ^MMM@@@@@@@@@@@MP" ,ggppww__                Terminal: /dev/pts/0
          `""""" _wNNNNNNNNNNNNNNNNNNN        CPU: Loongson-3A6000 (8)
              _gBNNNNNNNNNNNNNNNNNP"          GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X
          _wNNNNNNNNNNNNNNNNNNMP`             Memory: 2.52 GiB / 15.72 GiB (16%)
       _gBNNNNNNNNNNNNNNNNNP"                 Network: 1 Gbps
   _wNNNNNNNNNNNNNNNNNNNM^                    Bluetooth: Realtek Semiconductor Corp. Bluetooth Radio
   ""Y^^MNNNNNNNNNNNNP`                       BIOS: Loongson 4.0 (06/07/23 15:26:20)
           `"""""""
```

But I have no experience in this area, especially I didn't find any document describing `va_list` on LoongArch64, so I'm looking forward to some experts in this field to review this PR.